### PR TITLE
Fix missing gossipsub logs

### DIFF
--- a/common/logging/src/tracing_libp2p_discv5_logging_layer.rs
+++ b/common/logging/src/tracing_libp2p_discv5_logging_layer.rs
@@ -28,7 +28,7 @@ where
         };
 
         let mut writer = match target {
-            "gossipsub" => self.libp2p_non_blocking_writer.clone(),
+            "libp2p_gossipsub" => self.libp2p_non_blocking_writer.clone(),
             "discv5" => self.discv5_non_blocking_writer.clone(),
             _ => return,
         };


### PR DESCRIPTION
## Issue Addressed

- https://github.com/sigp/lighthouse/pull/7168
- https://github.com/sigp/lighthouse/issues/7148

## Proposed Changes

In https://github.com/sigp/lighthouse/pull/7057, we switched from our fork (which was included in lighthouse) to [sigp/rust-libp2p](https://github.com/sigp/rust-libp2p). During the switch, the package name was also changed from `gossipsub` to [`libp2p-gossipsub`](https://github.com/sigp/rust-libp2p/blob/sigp-gossipsub/protocols/gossipsub/Cargo.toml#L2), which is why gossipsub logs are missing.

<!--
## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->
