### PR TITLE
Apply `--logfile-debug-level` to `discv5.log` and `libp2p.log`

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -642,7 +642,11 @@ fn run<E: EthSpec>(
     }
 
     if let Some(libp2p_discv5_layer) = libp2p_discv5_layer {
-        logging_layers.push(libp2p_discv5_layer.boxed());
+        logging_layers.push(
+            libp2p_discv5_layer
+                .with_filter(logger_config.logfile_debug_level)
+                .boxed(),
+        );
     }
 
     logging_layers.push(MetricsLayer.boxed());


### PR DESCRIPTION
## Issue Addressed

I noticed that the `--logfile-debug-level` option does not affect to `discv5.log` or `libp2p.log`.

<!--
## Proposed Changes

Please list or describe the changes introduced by this PR.
-->

<!--
## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->