### PR TITLE
Try different date time formatting method

### DIFF
--- a/common/logging/src/sse_logging_components.rs
+++ b/common/logging/src/sse_logging_components.rs
@@ -2,6 +2,8 @@
 //! This module provides an implementation of `slog::Drain` that optionally writes to a channel if
 //! there are subscribers to a HTTP SSE stream.
 
+use chrono::format::StrftimeItems;
+use chrono::Utc;
 use serde_json::json;
 use serde_json::Value;
 use std::sync::Arc;
@@ -72,11 +74,10 @@ impl TracingEventVisitor {
 
     fn finish(self, metadata: &tracing::Metadata<'_>) -> Value {
         let mut log_entry = serde_json::Map::new();
+        let fmt = StrftimeItems::new("%b %d %H:%M:%S%.3f");
         log_entry.insert(
             "time".to_string(),
-            json!(chrono::Local::now()
-                .format("%b %d %H:%M:%S%.3f")
-                .to_string()),
+            json!(Utc::now().format_with_items(fmt).to_string()),
         );
         log_entry.insert("level".to_string(), json!(metadata.level().to_string()));
         log_entry.insert("target".to_string(), json!(metadata.target()));

--- a/common/logging/src/tracing_libp2p_discv5_logging_layer.rs
+++ b/common/logging/src/tracing_libp2p_discv5_logging_layer.rs
@@ -1,4 +1,5 @@
-use chrono::Local;
+use chrono::format::StrftimeItems;
+use chrono::Utc;
 use logroller::{LogRollerBuilder, Rotation, RotationSize};
 use std::io::Write;
 use std::path::PathBuf;
@@ -20,7 +21,8 @@ where
     fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<S>) {
         let meta = event.metadata();
         let log_level = meta.level();
-        let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+        let fmt = StrftimeItems::new("%b %d %H:%M:%S%.3f");
+        let timestamp = Utc::now().format_with_items(fmt).to_string();
 
         let target = match meta.target().split_once("::") {
             Some((crate_name, _)) => crate_name,

--- a/common/logging/src/tracing_logging_layer.rs
+++ b/common/logging/src/tracing_logging_layer.rs
@@ -1,5 +1,6 @@
 use crate::utils::is_ascii_control;
 
+use chrono::format::StrftimeItems;
 use chrono::prelude::*;
 use serde_json::{Map, Value};
 use std::collections::HashMap;
@@ -71,8 +72,9 @@ where
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<S>) {
         let meta = event.metadata();
         let log_level = meta.level();
+        let fmt = StrftimeItems::new("%b %d %H:%M:%S%.3f");
         let timestamp = if !self.disable_log_timestamp {
-            Local::now().format("%b %d %H:%M:%S%.3f").to_string()
+            Utc::now().format_with_items(fmt).to_string()
         } else {
             String::new()
         };


### PR DESCRIPTION
## Issue Addressed

See this comment: https://github.com/sigp/lighthouse/pull/7168#discussion_r2020951699

Using `Local::now().format()` seems to cause a bit of CPU overhead (**~11.44%**).

This PR experiments with formatting timestamp with `StrftimeItems` and `Utc::now()`, instead of `Local::now().format`.

A quick profiling pass shows **~3.58%** CPU overhead.

Note: this was a quick experiment and not well tested.